### PR TITLE
Fix PR bot displayed links

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "scripts": {
     "downloadEmulators": "firebase init emulators",
-    "emulate": "firebase emulators:start --only functions,firestore",
+    "emulate": "tsc && firebase emulators:start --only functions,firestore",
     "lint": "eslint --fix --ext .js,.ts .",
     "lint:fix": "eslint --fix --ext .js,.ts .",
     "build": "tsc",

--- a/functions/src/handleDefault.ts
+++ b/functions/src/handleDefault.ts
@@ -8,7 +8,7 @@ export const getPrNumberFromUrl = (url: string) => {
   return url.split('/').pop() ?? '';
 };
 
-const isUrl = (text: string) => {
+export const isUrl = (text: string) => {
   let url;
 
   try {

--- a/functions/src/handleDefault.ts
+++ b/functions/src/handleDefault.ts
@@ -55,7 +55,7 @@ const handleDefault = async (
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `<@${nextReviewerId}> is in charge of reviewing pull request <${url}|#${pr}>`,
+              text: `<@${nextReviewerId}> is in charge of reviewing pull request [#${pr}](${url})`,
             },
           },
           {

--- a/functions/tests/index.spec.ts
+++ b/functions/tests/index.spec.ts
@@ -68,8 +68,6 @@ test('url parser should return correct PR number', () => {
 test('isUrl should return true for valid url', () => {
   const url = 'https://git.corp.adobe.com/AnalyticsUI/audience-publishing/pull/158';
   const url2 = 'http://git.corp.adobe.com/AnalycitcsUI/web-spa/pull/158';
-  const url3 = 'https://git.corp.adobe.com/AnalyticsUI/audience-publishing/pull/193'
   expect(isUrl(url)).toBe(true);
   expect(isUrl(url2)).toBe(true);
-  expect(isUrl(url3)).toBe(true);
 });

--- a/functions/tests/index.spec.ts
+++ b/functions/tests/index.spec.ts
@@ -5,7 +5,7 @@ import {
   initializeTestEnvironment,
   RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { getPrNumberFromUrl } from '../src/handleDefault';
+import { getPrNumberFromUrl, isUrl } from '../src/handleDefault';
 
 let testEnv: RulesTestEnvironment;
 let queueDoc: FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>;
@@ -63,4 +63,13 @@ test('url parser should return correct PR number', () => {
   const res2 = getPrNumberFromUrl(url2);
   expect(res).toBe(num);
   expect(res2).toBe(num2);
+});
+
+test('isUrl should return true for valid url', () => {
+  const url = 'https://git.corp.adobe.com/AnalyticsUI/audience-publishing/pull/158';
+  const url2 = 'http://git.corp.adobe.com/AnalycitcsUI/web-spa/pull/158';
+  const url3 = 'https://git.corp.adobe.com/AnalyticsUI/audience-publishing/pull/193'
+  expect(isUrl(url)).toBe(true);
+  expect(isUrl(url2)).toBe(true);
+  expect(isUrl(url3)).toBe(true);
 });


### PR DESCRIPTION
This should mean we can put in either full links for a PR from any repo, or just a number for PR from web_spa